### PR TITLE
Feat: Modify kit to accept block

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/moneyclip-io/BitcoinCore.Swift.git", branch: "feat/modify-checkpoint-to-accept-block"),
         .package(url: "https://github.com/horizontalsystems/HdWalletKit.Swift.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/horizontalsystems/Hodler.Swift.git", .upToNextMajor(from: "1.0.0")),
+        .package(url: "https://github.com/moneyclip-io/Hodler.Swift.git", branch: "feat/use-diff-bitcoincore-dependency"),
         .package(url: "https://github.com/horizontalsystems/HsToolKit.Swift.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/horizontalsystems/HsCryptoKit.Swift.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/horizontalsystems/HsExtensions.Swift.git", .upToNextMajor(from: "1.0.0")),

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["BitcoinKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/horizontalsystems/BitcoinCore.Swift.git", .upToNextMajor(from: "1.0.0")),
+        .package(url: "https://github.com/moneyclip-io/BitcoinCore.Swift.git", branch: "feat/modify-checkpoint-to-accept-block"),
         .package(url: "https://github.com/horizontalsystems/HdWalletKit.Swift.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/horizontalsystems/Hodler.Swift.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/horizontalsystems/HsToolKit.Swift.git", .upToNextMajor(from: "1.0.0")),

--- a/Sources/BitcoinKit/Classes/Core/Kit.swift
+++ b/Sources/BitcoinKit/Classes/Core/Kit.swift
@@ -20,7 +20,7 @@ public class Kit: AbstractKit {
         }
     }
 
-    public convenience init(seed: Data, purpose: Purpose, walletId: String, syncMode: BitcoinCore.SyncMode = .api, networkType: NetworkType = .mainNet, confirmationsThreshold: Int = 6, logger: Logger?) throws {
+    public convenience init(seed: Data, purpose: Purpose, walletId: String, providedBlock: Block?, syncMode: BitcoinCore.SyncMode = .api, networkType: NetworkType = .mainNet, confirmationsThreshold: Int = 6, logger: Logger?) throws {
         let version: HDExtendedKeyVersion
         switch purpose {
         case .bip44: version = .xprv
@@ -30,27 +30,28 @@ public class Kit: AbstractKit {
         let masterPrivateKey = HDPrivateKey(seed: seed, xPrivKey: version.rawValue)
 
         try self.init(extendedKey: .private(key: masterPrivateKey),
-                walletId: walletId,
-                syncMode: syncMode,
-                networkType: networkType,
-                confirmationsThreshold: confirmationsThreshold,
-                logger: logger)
+                      walletId: walletId,
+                      providedBlock: providedBlock,
+                      syncMode: syncMode,
+                      networkType: networkType,
+                      confirmationsThreshold: confirmationsThreshold,
+                      logger: logger)
     }
 
-    public init(extendedKey: HDExtendedKey, walletId: String, syncMode: BitcoinCore.SyncMode = .api, networkType: NetworkType = .mainNet, confirmationsThreshold: Int = 6, logger: Logger?) throws {
+    public init(extendedKey: HDExtendedKey, walletId: String, providedBlock: Block?, syncMode: BitcoinCore.SyncMode = .api, networkType: NetworkType = .mainNet, confirmationsThreshold: Int = 6, logger: Logger?) throws {
         let network: INetwork
         let logger = logger ?? Logger(minLogLevel: .verbose)
 
         let initialSyncApi: ISyncTransactionApi?
         switch networkType {
             case .mainNet:
-                network = MainNet()
+            network = MainNet(providedBlock: providedBlock)
                 initialSyncApi = BlockchainComApi(url: "https://blockchain.info", hsUrl: "https://api.blocksdecoded.com/v1/blockchains/bitcoin", logger: logger)
             case .testNet:
-                network = TestNet()
+            network = TestNet(providedBlock: providedBlock)
                 initialSyncApi = BCoinApi(url: "https://btc-testnet.horizontalsystems.xyz/api", logger: logger)
             case .regTest:
-                network = RegTest()
+            network = RegTest(providedBlock: providedBlock)
                 initialSyncApi = nil
         }
 

--- a/Sources/BitcoinKit/Classes/Core/Kit.swift
+++ b/Sources/BitcoinKit/Classes/Core/Kit.swift
@@ -5,7 +5,7 @@ import Hodler
 import RxSwift
 import HsToolKit
 
-public class Kit: AbstractKit {
+public final class Kit: AbstractKit {
     private static let heightInterval = 2016                                    // Default block count in difficulty change circle ( Bitcoin )
     private static let targetSpacing = 10 * 60                                  // Time to mining one block ( 10 min. Bitcoin )
     private static let maxTargetBits = 0x1d00ffff                               // Initially and max. target difficulty for blocks

--- a/Sources/BitcoinKit/Classes/Network/MainNet.swift
+++ b/Sources/BitcoinKit/Classes/Network/MainNet.swift
@@ -14,6 +14,7 @@ public class MainNet: INetwork {
     public let coinType: UInt32 = 0
     public let sigHash: SigHashType = .bitcoinAll
     public var syncableFromApi: Bool = true
+    public let providedBlock: Block?
 
     public let dnsSeeds = [
         "x5.seed.bitcoin.sipa.be",             // Pieter Wuille
@@ -28,6 +29,8 @@ public class MainNet: INetwork {
 
     public let dustRelayTxFee = 3000 //  https://github.com/bitcoin/bitcoin/blob/master/src/policy/policy.h#L52
 
-    public init() {}
+    public init(providedBlock: Block?) {
+        self.providedBlock = providedBlock
+    }
 
 }

--- a/Sources/BitcoinKit/Classes/Network/RegTest.swift
+++ b/Sources/BitcoinKit/Classes/Network/RegTest.swift
@@ -14,6 +14,7 @@ class RegTest: INetwork {
     let coinType: UInt32 = 1
     let sigHash: SigHashType = .bitcoinAll
     var syncableFromApi: Bool = false
+    let providedBlock: Block?
 
     let dnsSeeds = [
          "btc-regtest.horizontalsystems.xyz",
@@ -23,4 +24,9 @@ class RegTest: INetwork {
     ]
 
     let dustRelayTxFee = 3000 // https://github.com/bitcoin/bitcoin/blob/c536dfbcb00fb15963bf5d507b7017c241718bf6/src/policy/policy.h#L50
+    
+    init(providedBlock: Block?) {
+        self.providedBlock = providedBlock
+    }
+    
 }

--- a/Sources/BitcoinKit/Classes/Network/TestNet.swift
+++ b/Sources/BitcoinKit/Classes/Network/TestNet.swift
@@ -16,6 +16,7 @@ class TestNet: INetwork {
     let coinType: UInt32 = 1
     let sigHash: SigHashType = .bitcoinAll
     var syncableFromApi: Bool = true
+    let providedBlock: Block?
 
     let dnsSeeds = [
         "testnet-seed.bitcoin.petertodd.org",    // Peter Todd
@@ -26,4 +27,9 @@ class TestNet: INetwork {
     ]
 
     let dustRelayTxFee = 3000 // https://github.com/bitcoin/bitcoin/blob/c536dfbcb00fb15963bf5d507b7017c241718bf6/src/policy/policy.h#L50
+    
+    init(providedBlock: Block?) {
+        self.providedBlock = providedBlock
+    }
+    
 }


### PR DESCRIPTION
# Description
- Modify `Kit` to accept block to be initialized with.
- Make `Kit` class _final_, so that it can be extended from parent projects when used as dependency.
- Point `BitcoinCore.Swift` and `Hodler.Swift` dependencies to `Coinmama` repos.