### PR TITLE
Feat sc-8646: Use Blockchain API for Testnet Sync

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,9 +13,9 @@ let package = Package(
             targets: ["BitcoinKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/moneyclip-io/BitcoinCore.Swift.git", branch: "feat/modify-checkpoint-to-accept-block"),
+        .package(url: "https://github.com/moneyclip-io/BitcoinCore.Swift.git", branch: "feat/sc-8646-Use-Blockchain-API-for-Testnet-Sync"),
         .package(url: "https://github.com/horizontalsystems/HdWalletKit.Swift.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/moneyclip-io/Hodler.Swift.git", branch: "feat/use-diff-bitcoincore-dependency"),
+        .package(url: "https://github.com/moneyclip-io/Hodler.Swift.git", branch: "feat/sc-8646-Use-Blockchain-API-for-Testnet-Sync"),
         .package(url: "https://github.com/horizontalsystems/HsToolKit.Swift.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/horizontalsystems/HsCryptoKit.Swift.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/horizontalsystems/HsExtensions.Swift.git", .upToNextMajor(from: "1.0.0")),

--- a/Sources/BitcoinKit/Classes/Core/Kit.swift
+++ b/Sources/BitcoinKit/Classes/Core/Kit.swift
@@ -20,7 +20,7 @@ public final class Kit: AbstractKit {
         }
     }
 
-    public convenience init(seed: Data, purpose: Purpose, walletId: String, providedBlock: Block?, apiInfo: APIInfo? = nil, syncMode: BitcoinCore.SyncMode = .api, networkType: NetworkType = .mainNet, confirmationsThreshold: Int = 6, logger: Logger?) throws {
+    public convenience init(seed: Data, purpose: Purpose, walletId: String, providedBlock: Block?, apiInfo: APIInfo, syncMode: BitcoinCore.SyncMode = .api, networkType: NetworkType = .mainNet, confirmationsThreshold: Int = 6, logger: Logger?) throws {
         let version: HDExtendedKeyVersion
         switch purpose {
         case .bip44: version = .xprv
@@ -39,7 +39,7 @@ public final class Kit: AbstractKit {
                       logger: logger)
     }
 
-    public init(extendedKey: HDExtendedKey, walletId: String, providedBlock: Block?, apiInfo: APIInfo? = nil, syncMode: BitcoinCore.SyncMode = .api, networkType: NetworkType = .mainNet, confirmationsThreshold: Int = 6, logger: Logger?) throws {
+    public init(extendedKey: HDExtendedKey, walletId: String, providedBlock: Block?, apiInfo: APIInfo, syncMode: BitcoinCore.SyncMode = .api, networkType: NetworkType = .mainNet, confirmationsThreshold: Int = 6, logger: Logger?) throws {
         let network: INetwork
         let logger = logger ?? Logger(minLogLevel: .verbose)
         
@@ -50,12 +50,7 @@ public final class Kit: AbstractKit {
             initialSyncApi = BlockchainComApi(url: "https://blockchain.info", hsUrl: "https://api.blocksdecoded.com/v1/blockchains/bitcoin", logger: logger)
         case .testNet:
             network = TestNet(providedBlock: providedBlock)
-            
-            if let apiInfo = apiInfo {
-                initialSyncApi = BlockchainApi(url: apiInfo.url, authKey: apiInfo.authKey, logger: logger)
-            } else {
-                initialSyncApi = BCoinApi(url: "https://btc-testnet.horizontalsystems.xyz/api", logger: logger)
-            }
+            initialSyncApi = BCoinApi(url: apiInfo.url, authKey: apiInfo.authKey, logger: logger)
         case .regTest:
             network = RegTest(providedBlock: providedBlock)
             initialSyncApi = nil

--- a/Sources/BitcoinKit/Classes/Core/Kit.swift
+++ b/Sources/BitcoinKit/Classes/Core/Kit.swift
@@ -20,7 +20,7 @@ public final class Kit: AbstractKit {
         }
     }
 
-    public convenience init(seed: Data, purpose: Purpose, walletId: String, providedBlock: Block?, syncMode: BitcoinCore.SyncMode = .api, networkType: NetworkType = .mainNet, authKey: String? = nil, confirmationsThreshold: Int = 6, logger: Logger?) throws {
+    public convenience init(seed: Data, purpose: Purpose, walletId: String, providedBlock: Block?, apiInfo: APIInfo? = nil, syncMode: BitcoinCore.SyncMode = .api, networkType: NetworkType = .mainNet, authKey: String? = nil, confirmationsThreshold: Int = 6, logger: Logger?) throws {
         let version: HDExtendedKeyVersion
         switch purpose {
         case .bip44: version = .xprv
@@ -32,6 +32,7 @@ public final class Kit: AbstractKit {
         try self.init(extendedKey: .private(key: masterPrivateKey),
                       walletId: walletId,
                       providedBlock: providedBlock,
+                      apiInfo: apiInfo,
                       syncMode: syncMode,
                       networkType: networkType,
                       confirmationsThreshold: confirmationsThreshold,

--- a/Sources/BitcoinKit/Classes/Core/Kit.swift
+++ b/Sources/BitcoinKit/Classes/Core/Kit.swift
@@ -20,7 +20,7 @@ public final class Kit: AbstractKit {
         }
     }
 
-    public convenience init(seed: Data, purpose: Purpose, walletId: String, providedBlock: Block?, syncMode: BitcoinCore.SyncMode = .api, networkType: NetworkType = .mainNet, confirmationsThreshold: Int = 6, logger: Logger?) throws {
+    public convenience init(seed: Data, purpose: Purpose, walletId: String, providedBlock: Block?, syncMode: BitcoinCore.SyncMode = .api, networkType: NetworkType = .mainNet, authKey: String? = nil, confirmationsThreshold: Int = 6, logger: Logger?) throws {
         let version: HDExtendedKeyVersion
         switch purpose {
         case .bip44: version = .xprv
@@ -38,21 +38,26 @@ public final class Kit: AbstractKit {
                       logger: logger)
     }
 
-    public init(extendedKey: HDExtendedKey, walletId: String, providedBlock: Block?, syncMode: BitcoinCore.SyncMode = .api, networkType: NetworkType = .mainNet, confirmationsThreshold: Int = 6, logger: Logger?) throws {
+    public init(extendedKey: HDExtendedKey, walletId: String, providedBlock: Block?, apiInfo: APIInfo? = nil, syncMode: BitcoinCore.SyncMode = .api, networkType: NetworkType = .mainNet, confirmationsThreshold: Int = 6, logger: Logger?) throws {
         let network: INetwork
         let logger = logger ?? Logger(minLogLevel: .verbose)
-
+        
         let initialSyncApi: ISyncTransactionApi?
         switch networkType {
-            case .mainNet:
+        case .mainNet:
             network = MainNet(providedBlock: providedBlock)
-                initialSyncApi = BlockchainComApi(url: "https://blockchain.info", hsUrl: "https://api.blocksdecoded.com/v1/blockchains/bitcoin", logger: logger)
-            case .testNet:
+            initialSyncApi = BlockchainComApi(url: "https://blockchain.info", hsUrl: "https://api.blocksdecoded.com/v1/blockchains/bitcoin", logger: logger)
+        case .testNet:
             network = TestNet(providedBlock: providedBlock)
+            
+            if let apiInfo = apiInfo {
+                initialSyncApi = BlockchainApi(url: apiInfo.url, authKey: apiInfo.authKey, logger: logger)
+            } else {
                 initialSyncApi = BCoinApi(url: "https://btc-testnet.horizontalsystems.xyz/api", logger: logger)
-            case .regTest:
+            }
+        case .regTest:
             network = RegTest(providedBlock: providedBlock)
-                initialSyncApi = nil
+            initialSyncApi = nil
         }
 
         let purpose = extendedKey.info.purpose
@@ -131,4 +136,13 @@ extension Kit {
         "\(walletId)-\(networkType.rawValue)-\(purpose.description)-\(syncMode)"
     }
 
+}
+
+extension Kit {
+    
+    public struct APIInfo {
+        let url: String
+        let authKey: String
+    }
+    
 }

--- a/Sources/BitcoinKit/Classes/Core/Kit.swift
+++ b/Sources/BitcoinKit/Classes/Core/Kit.swift
@@ -20,7 +20,7 @@ public final class Kit: AbstractKit {
         }
     }
 
-    public convenience init(seed: Data, purpose: Purpose, walletId: String, providedBlock: Block?, apiInfo: APIInfo? = nil, syncMode: BitcoinCore.SyncMode = .api, networkType: NetworkType = .mainNet, authKey: String? = nil, confirmationsThreshold: Int = 6, logger: Logger?) throws {
+    public convenience init(seed: Data, purpose: Purpose, walletId: String, providedBlock: Block?, apiInfo: APIInfo? = nil, syncMode: BitcoinCore.SyncMode = .api, networkType: NetworkType = .mainNet, confirmationsThreshold: Int = 6, logger: Logger?) throws {
         let version: HDExtendedKeyVersion
         switch purpose {
         case .bip44: version = .xprv

--- a/Sources/BitcoinKit/Classes/Core/Kit.swift
+++ b/Sources/BitcoinKit/Classes/Core/Kit.swift
@@ -144,6 +144,11 @@ extension Kit {
     public struct APIInfo {
         let url: String
         let authKey: String
+        
+        public init(url: String, authKey: String) {
+            self.url = url
+            self.authKey = authKey
+        }
     }
     
 }


### PR DESCRIPTION
# Shortcut
[8646](https://app.shortcut.com/moneyclipio/story/8646/bitcoin-kit-use-blockchain-api-for-testnet-sync)

# Description
- Update `Kit` initializers to take `APIInfo` consisting of url and authKey.
- Pass `APIInfo` into `BCoinApi` class.
- Update `BitcoinCore` and `Hodler` dependencies.