### PR TITLE
Feat sc-8790: Fetch Blockhashes From Blockchain API for BitcoinKit Mainnet

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,9 +13,9 @@ let package = Package(
             targets: ["BitcoinKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/moneyclip-io/BitcoinCore.Swift.git", branch: "feat/sc-8646-Use-Blockchain-API-for-Testnet-Sync"),
+        .package(url: "https://github.com/moneyclip-io/BitcoinCore.Swift.git", branch: "feat/8790-Fetch-Blockhashes-From-Blockchain-API-for-Mainnet"),
         .package(url: "https://github.com/horizontalsystems/HdWalletKit.Swift.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/moneyclip-io/Hodler.Swift.git", branch: "feat/sc-8646-Use-Blockchain-API-for-Testnet-Sync"),
+        .package(url: "https://github.com/moneyclip-io/Hodler.Swift.git", branch: "feat/8790-Fetch-Blockhashes-From-Blockchain-API-for-Mainnet"),
         .package(url: "https://github.com/horizontalsystems/HsToolKit.Swift.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/horizontalsystems/HsCryptoKit.Swift.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/horizontalsystems/HsExtensions.Swift.git", .upToNextMajor(from: "1.0.0")),

--- a/Package.swift
+++ b/Package.swift
@@ -13,9 +13,9 @@ let package = Package(
             targets: ["BitcoinKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/moneyclip-io/BitcoinCore.Swift.git", branch: "feat/8790-Fetch-Blockhashes-From-Blockchain-API-for-Mainnet"),
+        .package(url: "https://github.com/moneyclip-io/BitcoinCore.Swift.git", branch: "feat/sc-8790-Fetch-Blockhashes-From-Blockchain-API-for-Mainnet"),
         .package(url: "https://github.com/horizontalsystems/HdWalletKit.Swift.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/moneyclip-io/Hodler.Swift.git", branch: "feat/8790-Fetch-Blockhashes-From-Blockchain-API-for-Mainnet"),
+        .package(url: "https://github.com/moneyclip-io/Hodler.Swift.git", branch: "feat/sc-8790-Fetch-Blockhashes-From-Blockchain-API-for-Mainnet"),
         .package(url: "https://github.com/horizontalsystems/HsToolKit.Swift.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/horizontalsystems/HsCryptoKit.Swift.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/horizontalsystems/HsExtensions.Swift.git", .upToNextMajor(from: "1.0.0")),

--- a/Sources/BitcoinKit/Classes/Core/Kit.swift
+++ b/Sources/BitcoinKit/Classes/Core/Kit.swift
@@ -49,7 +49,7 @@ public final class Kit: AbstractKit {
             network = MainNet(providedBlock: providedBlock)
             let baseUrl = apiInfo.baseUrl
             let authKey = apiInfo.authKey
-            let hsUrl = baseUrl + "/blockchainapi/bitcoin/mainnet"
+            let hsUrl = baseUrl + "/bitcoin/mainnet"
             initialSyncApi = BlockchainComApi(url: "https://blockchain.info", hsUrl: hsUrl, jwtUrl: baseUrl, authKey: authKey, logger: logger)
         case .testNet:
             network = TestNet(providedBlock: providedBlock)


### PR DESCRIPTION
# Shortcut
[8790](https://app.shortcut.com/moneyclipio/story/8790/bitcoinkit-ios-fetch-blockhashes-from-blockchain-api-for-bitcoinkit-mainnet)

# Description
- Pass `APIInfo` into `BlockchainComApi` class.
- Remove field from url path.
- Update `BitcoinCore` and `Hodler` dependencies.